### PR TITLE
Enhance Navigation: Click Functionality to Change Low and High Notes

### DIFF
--- a/src/app/components/scroll-image-selector/scroll-image-selector.component.ts
+++ b/src/app/components/scroll-image-selector/scroll-image-selector.component.ts
@@ -28,7 +28,8 @@ const TICK_SOUND = new Howl({ src: ['assets/sounds/tick_weak.wav'] });
 
       <div class="scrollable" 
             #scrollContainer 
-            (scroll)="onScroll()">
+            (scroll)="onScroll()"
+            (click)="onClick($event)">
             <div *ngFor="let image of images;" class="scroll-element" [style.height]="scrollElementHeight + 'px'">
                 
             </div>
@@ -163,5 +164,30 @@ export class ScrollImageComponent implements AfterViewInit, OnChanges{
             this.snapTimeout = null;
         }, 100);
     }
-
+    onClick(event: MouseEvent) {
+        const element = this.scrollContainer.nativeElement;
+        const containerHeight = element.clientHeight; // Height of the scrollable container
+        const clickPosition = event.clientY - element.getBoundingClientRect().top; // Y-position relative to container
+        
+        // Invert the index calculation
+        const idx = Math.round((1 - clickPosition / containerHeight) * (this.images.length -1));
+    
+        // Ensure the index stays within valid bounds
+        const boundedIndex = Math.max(0, Math.min(this.images.length - 1, idx));
+    
+        if (boundedIndex !== this.index) {
+            Haptics.selectionChanged();
+        }
+    
+        this.index = boundedIndex;
+        this.image = this.images[this.index];
+        this.indexChange.emit(this.index);
+    
+        // Scroll smoothly to the selected image position
+        const snapTo = boundedIndex * this.scrollElementHeight;
+        element.scrollTo({ top: snapTo, behavior: 'smooth' });
+    }
+    
+    
 }
+

--- a/src/app/components/scroll-image-selector/scroll-image-selector.component.ts
+++ b/src/app/components/scroll-image-selector/scroll-image-selector.component.ts
@@ -188,6 +188,5 @@ export class ScrollImageComponent implements AfterViewInit, OnChanges{
         element.scrollTo({ top: snapTo, behavior: 'smooth' });
     }
     
-    
 }
 


### PR DESCRIPTION
Previously, users could only change the note positions by scrolling through the list. While this worked, it lacked precision and quick navigation. This update introduces a click functionality, allowing users to directly select the low note and high note with a simple click.

**Enhancement Details:**
Clicking at the top of the scrollable area now moves the first note to the top.
Clicking at the bottom moves the last note to the top.
Clicking anywhere in between moves the closest corresponding note to the top.
Maintains smooth scrolling behavior while improving usability.

**Importance of this feature:**
Provides a faster and more intuitive way to navigate through notes.
Reduces the need for excessive scrolling, making it more accessible and user-friendly.
Ensures precise selection, especially useful when working with a large number of notes.

**After effects:**

https://github.com/user-attachments/assets/4432300a-b152-40e6-a412-ba16d7879b38


